### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Get from Rubygem.org: https://rubygems.org/gems/xaes_256_gcm
 
 ```ruby
 require "xaes_256_gcm"
-require "securerandom"
 
 key = # assign to some key.
 plaintext = "Hello XAES-256-GCM from Ruby"


### PR DESCRIPTION
We don't have a dependency on `SecureRandom` in the README sample now.